### PR TITLE
Popout fixes

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1687,7 +1687,6 @@ function updateScaleInputs(newScale, maxScale) {
 	imageScaleInputRange.attr('max', maxScale);
 }
 
-
 //Start Quick Roll Menu//
 
 function open_quick_roll_menu(e){
@@ -1695,7 +1694,7 @@ function open_quick_roll_menu(e){
 	console.log("Opening Roll menu")
 	$("#qrm_dialog").remove();
 
-	qrm = $("<div id='qrm_dialog'></div>");
+	let qrm = $("<div id='qrm_dialog'></div>");
 	qrm.css('background', "#f9f9f9");
 	qrm.css('width', '410px');
 	qrm.css('top', e.clientY+'px');
@@ -1733,7 +1732,14 @@ function open_quick_roll_menu(e){
 	qrm_title_bar_popout.click(function() {
 		qrm.hide();
 		let name = "Quick Roll Menu";
+		//We need to delete and reset the select menu here. The iconselectmenu doesn't clone right. so we need to delete and reinit. 
+		$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").iconselectmenu( "destroy" );
+		$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").iconselectmenu( "destroy" );
 		popoutWindow(name, $("#qrm_dialog"), $("#qrm_dialog").width(),  $("#qrm_dialog").height()-25);//subtract titlebar height
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').prop('selectedIndex',0);
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').addClass( "ui-menu-icons" );
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').prop('selectedIndex',0);
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').addClass( "ui-menu-icons" );
 		qrm_update_popout();
 	})
 	qrm_title_bar.append(qrm_title_bar_popout);
@@ -1768,36 +1774,54 @@ function open_quick_roll_menu(e){
 			$("#qrm_dialog").css("visibility", "visible");
 		}
 	});
-	qrm_dc_input = $('<input class="general_input" id="qrm_save_dc" placeholder="Save DC" name="save_dc" title="Enter the value for the DC of the saving throw."></input>')
+	let qrm_dc_input = $('<input class="menu_roll_input" id="qrm_save_dc" placeholder="Save DC" name="save_dc" title="Enter the value for the DC of the saving throw."></input>')
 	//qrm_dc_input.tooltip({show: { duration: 1000 }});
-	qrm_dc_input.attr('style', 'width: 24% !important');
+	qrm_dc_input.attr('style', 'width: 25% !important');
 
-	save_type_dropdown = $('<select class="general_input" id="qrm_save_dropdown" onchange="save_type_change(this)" title="Select the type of saving throw to be made. ">Save Type</select>')
-	save_type_dropdown.append($('<option value="1">Dexterity</option>')) 
-	save_type_dropdown.append($('<option value="4">Wisdom</option>'))
-	save_type_dropdown.append($('<option value="2">Constitution</option>'))
-	save_type_dropdown.append($('<option value="0">Strength</option>'))
-	save_type_dropdown.append($('<option value="3">Intelligence</option>'))
-	save_type_dropdown.append($('<option value="5">Charisma</option>'))
+	// Lets add the selectmenu image to each of these save types too... use the images from character sheet for save.
+	let save_type_dropdown = $('<select class="general_input" id="qrm_save_dropdown" title="Select the type of saving throw to be made. ">Save Type</select>')
+	save_type_dropdown.append($(`<option value="1" data-name="dex" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/dexterity.svg)'>Dexterity</option>`)) 
+	save_type_dropdown.append($(`<option value="4" data-name="wis" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/wisdom.svg)'>Wisdom</option>`))
+	save_type_dropdown.append($(`<option value="2" data-name="con" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/constitution.svg)'>Constitution</option>`))
+	save_type_dropdown.append($(`<option value="0" data-name="str" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/strength.svg)'>Strength</option>`))
+	save_type_dropdown.append($(`<option value="3" data-name="int" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/intelligence.svg)'>Intelligence</option>`))
+	save_type_dropdown.append($(`<option value="5" data-name="cha" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/charisma.svg)'>Charisma</option>`))
 	//save_type_dropdown.tooltip({show: { duration: 1000 }})
 	save_type_dropdown.attr('style', 'width: 25% !important');
-	damage_input  = $('<input class="general_input" id="damage_failed_save" placeholder="Damage/Roll" title="Enter the integer value for damage or the roll to be made i.e. 8d6"></input>')
-	//damage_input.tooltip({show: { duration: 1000 }})
-	damage_input.attr('style', 'width: 24% !important');
 
-	half_damage_input = $('<input class="general_input" id="half_damage_save" placeholder="Success Damage" title="Enter the integer value for half damage, or autopopulate from damage entry as half rounded down.""></input>')
+	$( function() {
+		$.widget( "custom.iconselectmenu", $.ui.selectmenu, {
+		_renderItem: function( ul, item ) {
+			var li = $( `<li class='icon-avatar' >` )
+			wrapper = $( "<div>", { text: item.label } );
+			$( "<li>", {
+			style: 'background-image: ' + item.element.attr( "data-style" ),
+			"class": "ui-icon " + item.element.attr( "data-class" )}).appendTo(wrapper);
+			return li.append( wrapper ).appendTo( ul );
+		}
+		});
+		$("#qrm_save_dropdown")
+		.iconselectmenu({ change: function( event, ui ) { save_type_change(this); }})
+    		.addClass( "ui-menu-icons" );
+	});
+
+	let damage_input  = $('<input class="menu_roll_input" id="hp_adjustment_failed_save" placeholder="Damage/Roll" title="Enter the integer value for damage or the roll to be made i.e. 8d6"></input>')
+	//damage_input.tooltip({show: { duration: 1000 }})
+	damage_input.attr('style', 'width: 25% !important');
+
+	let half_damage_input = $('<input class="menu_roll_input" id="half_damage_save" placeholder="Success Damage" title="Enter the integer value for half damage, or autopopulate from damage entry as half rounded down.""></input>')
 	//half_damage_input.tooltip({show: { duration: 1000 }})
-	half_damage_input.attr('style', 'width: 24% !important');
+	half_damage_input.attr('style', 'width: 25% !important');
 
 	damage_input.change(function(){
-		_dmg = $('#damage_failed_save').val();
+		_dmg = $('#hp_adjustment_failed_save').val();
 		if (_dmg.includes('d')) {
 			var expression = _dmg
 			var roll = new rpgDiceRoller.DiceRoll(expression);
 			console.log(expression + "->" + roll.total);
 			//reassign to the input 
 			_dmg = roll.total
-			$('#damage_failed_save').val(_dmg);
+			$('#hp_adjustment_failed_save').val(_dmg);
 		}
 		else {
 			_dmg.replace(/[^\d.-]/g, '')
@@ -1807,9 +1831,11 @@ function open_quick_roll_menu(e){
 	});
 
 	//Roll Button 
-	qrm_roll=$("<button id='qrm_roll_button'>ROLL</button>");
+	let qrm_roll=$("<button id='qrm_roll_button' >ROLL</button>");
+	qrm_roll.css('width', '13%');
 	qrm_roll.click(function() {
 		$('#qrm_apply_damage').show()
+		$('#qrm_apply_healing').show()
 		$("#quick_roll_area").children('tr').children('td').find('#roll_bonus').each(function (){
 			let modifier = $(this).val().toLowerCase();
 			dice = '1d20'
@@ -1848,9 +1874,12 @@ function open_quick_roll_menu(e){
 	});
 
 	//Clear Button
-	qrm_clear = $("<button id='qrm_clear_all' >CLEAR </button>");
-	qrm_clear.css('right', '5px');
+	let qrm_clear = $("<button id='qrm_clear_all' >CLEAR </button>");
+	qrm_clear.css('width', '15%');
+	qrm_clear.css('bottom', '5px');
+	qrm_clear.css('right', '5px')
 	qrm_clear.css('position','absolute');
+
 	qrm_clear.click(function() {
 		$("#quick_roll_area").children('tr').each(function (){
 			$(this).find('#qrm_remove').click()
@@ -1858,59 +1887,94 @@ function open_quick_roll_menu(e){
 		qrm_update_popout();
 	});
 
-	//Update HP button 
-	update_hp = $("<button id='qrm_apply_damage'> Apply Damage/Healing </button>");
-	update_hp.click(function() {
-		$("#quick_roll_area").children('tr').each(function (){
-			let result = $(this).find('#qrm_roll_result').val();
-			let token = window.TOKEN_OBJECTS[$(this).attr('data-target')]
-			damage_failed_save = $('#damage_failed_save').val()
-			half_damage_save_success = $('#half_damage_save').val()
 
-			damage_failed_save = damage_failed_save.replace(/[^\d.-]/g, '');
-			half_damage_save_success = half_damage_save_success.replace(/[^\d.-]/g, '');
+	//Update HP buttons	
+	let qrm_hp_adjustment_wrapper=$('<div id="qrm_adjustment_wrapper" class="adjustments_wrapper"></div>');
 
-			if (result.includes('Fail')){
-				damage = damage_failed_save
-			}
-			else {
-				damage = half_damage_save_success
-			}
+	let damage_hp = $('<button title="Apply Roll as Damage" id="qrm_damage" value="ON" class="damage_heal_button active_roll_mod" >DAMAGE</button>')
+	damage_hp.click(function() {
+	
+		console.log($(this).val())
+		console.log($(this))
+		//toggle off the other button
+		$(heal_hp).val("OFF")
+		$(heal_hp).removeClass('active_roll_mod')
+		
+		if($(this).val() == "ON"){
+			$(this).val("OFF");
+			$(this).removeClass('active_roll_mod')
+		}
+	  	else if($(this).val() == "OFF"){
+			$(this).val("ON");
+			$(this).addClass('active_roll_mod')
+		}
+	});
+	let heal_hp = $('<button title="Apply Roll as Healing" id="qrm_healing" value="OFF" class="damage_heal_button">HEAL</button>')
+	heal_hp.click(function(){
+		
+		console.log('EHRE')
+		console.log($(this).val())
+		console.log($(this))
+		//toggle off the other button
+		$(damage_hp).val("OFF")
+		$(damage_hp).removeClass('active_roll_mod')
 
-			if(token.options.monster > 0){
-				_hp = $(this).find('#qrm_hp');
-				_max_hp = $(this).find('#qrm_maxhp')
-				//Lets not allow healing over maxhp
-				//Unless we are at max_hp then assume they want the temp hp? IDK about this.
-				if (_hp.val() < _max_hp.val() && _hp.val() - damage > _max_hp.val()){
-					_hp.val(max_hp.val());
-				}
-				else{
-					_hp.val(token.hp - damage);
-				}
-				_hp.trigger('change');
-			}
-			else {
-				// doing it this way, because Players might also have resistances or abilites and they should manage their own HP. 
-				if (damage > 0){
-					dmg_heal_text = token.options.name + " takes " + damage +" damage (adjust manually)";
-				}
-				else{
-					dmg_heal_text = token.options.name + " heals for " + damage +" (adjust manually)";
-				}
-					var msgdata = {
-					player: window.PLAYER_NAME,
-					img: window.PLAYER_IMG,
-					text: dmg_heal_text,
-				};
-				window.MB.inject_chat(msgdata);
-			}
-			token.update_and_sync();
-			qrm_update_popout();
-		});
+		if($(this).val() == "ON"){
+			$(this).val("OFF");
+			$(this).removeClass('active_roll_mod')
+		}
+	  	else if($(this).val() == "OFF"){
+			$(this).val("ON");
+			$(this).addClass('active_roll_mod')
+		}
 	});
 
-	qrm_footer = $("<div id='quick_roll_footer' class='footer-input-wrapper tfoot'/>");
+	qrm_hp_adjustment_wrapper.append(heal_hp)
+	qrm_hp_adjustment_wrapper.append(damage_hp)
+
+	//Allow applying condtions with damage/healing after a failed save
+	apply_conditions = $('<select class="general_input" id="qrm_apply_conditions" title="Select a conditions to be applied on failed save."> Apply Conditions </select>');
+	apply_conditions.append($(`<option value='conditions' data-style="background-image: none !important;">Conditions</option>`))
+	apply_conditions.append($(`<option value='remove_all' data-class="dropdown-remove" >Remove All</option>`))
+	
+	STANDARD_CONDITIONS.forEach(conditionName => {
+		let cond_name = conditionName.toLowerCase().replaceAll("(", "-").replaceAll(")", "").replaceAll(" ", "-")
+		apply_conditions.append($(`<option value=${conditionName} data-name="${cond_name}" data-style="background-image: url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/conditions/${cond_name}.svg)";>${cond_name}</option>`));
+	});
+	CUSTOM_CONDITIONS.forEach(conditionName => {
+		let cond_name = conditionName.toLowerCase().replaceAll("(", "-").replaceAll(")", "").replaceAll(" ", "-")
+		if (cond_name.includes('#')){
+			apply_conditions.append($(`<option value=${conditionName} data-style="background-color: ${cond_name}; background-image: none;";>Custom Condition</option>`));
+		}
+		else{
+			let cond = $(`<option  value=${conditionName} data-name="${cond_name}" data-class="dropdown-${cond_name}";>${cond_name}</option>`)
+			apply_conditions.append(cond);
+		}
+	});
+	
+	$( function() {
+		$.widget( "custom.iconselectmenu", $.ui.selectmenu, {
+		_renderItem: function( ul, item ) {
+			var li = $( `<li class='icon-avatar' >` )
+			wrapper = $( "<div>", { text: item.label } );
+			$( "<li>", {
+			style: item.element.attr( "data-style" ),
+			"class": "ui-icon " + item.element.attr( "data-class" )}).appendTo(wrapper);
+			return li.append( wrapper ).appendTo( ul );
+		}
+		});
+		$("#qrm_apply_conditions")
+		.iconselectmenu()
+    	.iconselectmenu( "menuWidget")
+    		.addClass( "ui-menu-icons" );
+	});
+	
+	let apply_adjustments = $('<button title="Apply Damage/Healing and Conditions on failed save" id="qrm_apply_adjustments" class="general_input"> Apply </button>')
+	apply_adjustments.click(function() {
+		qrm_apply_hp_adjustment(healing=$('#qrm_healing').val());
+	});
+
+	let qrm_footer = $("<div id='quick_roll_footer' class='footer-input-wrapper tfoot'/>");
 	qrm_footer.css('bottom', '0');
 	qrm_footer.css('position','sticky');
 	qrm_footer.css('background', "#f9f9f9");
@@ -1920,9 +1984,15 @@ function open_quick_roll_menu(e){
 	qrm_footer.append(qrm_dc_input)
 	qrm_footer.append(save_type_dropdown)
 	qrm_footer.append(qrm_roll);
-	qrm_footer.append(update_hp);
+	qrm_footer.append(apply_conditions);
+	
+	qrm_footer.append(qrm_hp_adjustment_wrapper);
+	qrm_footer.append(apply_adjustments)
+	//qrm_footer.append(heal_hp);
+	//qrm_footer.append(damage_hp);
 	qrm_footer.append(qrm_clear);
-	update_hp.hide()
+	//damage_hp.hide()
+	//heal_hp.hide()
 
 	//header
 	qrm.append(qrm_title_bar);
@@ -2065,8 +2135,9 @@ function add_to_quick_roll_menu(token){
 	
 	if(token.isPlayer()){
 		hp_input.prop("disabled", true);
+		hp_input.css('color', 'gray')
 	}
-	hp_input.val(token.hp);
+	hp_input.val(token.options.hp);
 
 	if(hp_input.val() === '0'){
 		qrm_entry.toggleClass("ct_dead", true);
@@ -2082,8 +2153,9 @@ function add_to_quick_roll_menu(token){
 
 	if(token.isPlayer()){
 		maxhp_input.prop("disabled", true);
+		maxhp_input.css('color', 'gray')
 	}
-	maxhp_input.val(token.maxHp);
+	maxhp_input.val(token.options.max_hp);
 
 	if (!token.isPlayer()) {
 		hp_input.change(function(e) {
@@ -2091,16 +2163,16 @@ function add_to_quick_roll_menu(token){
 			var old = $("#tokens").find(selector);
 		
 			if (hp_input.val().trim().startsWith("+") || hp_input.val().trim().startsWith("-")) {
-				hp_input.val(Math.max(0, parseInt(token.hp) + parseInt(hp_input.val())));
+				hp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(hp_input.val())));
 			}
 
 			old.find(".hp").val(hp_input.val().trim());	
 
 			if(window.all_token_objects[token.options.id] != undefined){
-				window.all_token_objects[token.options.id].hp = hp_input.val();
+				window.all_token_objects[token.options.id].options.hp = hp_input.val();
 			}			
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
-				window.TOKEN_OBJECTS[token.options.id].hp = hp_input.val();
+				window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
 				window.TOKEN_OBJECTS[token.options.id].update_and_sync();
 			}			
 			qrm_update_popout();
@@ -2113,15 +2185,15 @@ function add_to_quick_roll_menu(token){
 			var old = $("#tokens").find(selector);
 
 			if (maxhp_input.val().trim().startsWith("+") || maxhp_input.val().trim().startsWith("-")) {
-				maxhp_input.val(Math.max(0, token.hp + parseInt(maxhp_input.val())));
+				maxhp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(maxhp_input.val())));
 			}
 
 			old.find(".max_hp").val(maxhp_input.val().trim());
 			if(window.all_token_objects[token.options.id] != undefined){
-				window.all_token_objects[token.options.id].maxHp = maxhp_input.val();
+				window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
 			}
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
-				window.TOKEN_OBJECTS[token.options.id].maxHp = maxhp_input.val();
+				window.TOKEN_OBJECTS[token.options.id].options.max_hp = maxhp_input.val();	
 				window.TOKEN_OBJECTS[token.options.id].update_and_sync();
 			}			
 			qrm_update_popout();
@@ -2260,8 +2332,8 @@ function qrm_fetch_stat(token) {
 		save_dropdown_value = parseInt($('#qrm_save_dropdown').val());
 		//This relies of player data being loaded, which may take a few seconds after the page opens
 		//if its a player character they have the save stored
-		const pc = find_pc_by_player_id(token.options.id);
-		roll_bonus = pc.abilities[save_dropdown_value]['save']
+		player_stats = window.PLAYER_STATS[token.options.id]
+		roll_bonus = player_stats.abilities[save_dropdown_value]['save']
 
 		if (roll_bonus >= 0){
 			roll_bonus = "+"+roll_bonus;
@@ -2324,6 +2396,7 @@ function qrm_update_popout(){
 		//$(childWindows['Quick Roll Menu'].document).find("body").empty("");
 		updatePopoutWindow("Quick Roll Menu", $("#qrm_dialog"));
 		removeFromPopoutWindow("Quick Roll Menu", "#quick_roll_title_bar");
+		removeFromPopoutWindow("Quick Roll Menu", $("#qrm_dialog #quick_roll_footer #qrm_save_dropdown"));
 		$(childWindows['Quick Roll Menu'].document).find("#qrm_dialog").css({
 			'display': 'block',
 			'top': '0',
@@ -2358,9 +2431,9 @@ function qrm_update_popout(){
 			$(`tr[data-target='${id}'] #roll_result`).trigger("change");
 			qrm_update_popout();
 		});	
-		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer input#damage_failed_save').change(function(e) {
-			$("#qrm_dialog #quick_roll_footer input#damage_failed_save").val($(this).val());
-			$("#qrm_dialog #quick_roll_footer input#damage_failed_save").trigger("change");
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save').change(function(e) {
+			$("#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save").val($(this).val());
+			$("#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save").trigger("change");
 			qrm_update_popout();
 		});	
 		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer input#half_damage_save').change(function(e) {
@@ -2373,12 +2446,97 @@ function qrm_update_popout(){
 			$('#qrm_dialog #quick_roll_footer input#qrm_save_dc').trigger("change");
 			qrm_update_popout();
 		});
+		//so we could redefine the iconselectmenu function here...but it doesn't work right and fixing it starts to get messy ...
+			
 		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').change(function(e) {
 			$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").val($(this).val());
 			$('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').trigger("change");
 			qrm_update_popout();
-		});	
+		});			
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').change(function(e) {
+			$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").val($(this).val());
+			$('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').trigger("change");
+			qrm_update_popout();
+		});
+		
 	}
+}
+
+function qrm_apply_hp_adjustment(healing=false){
+	$("#quick_roll_area").children('tr').each(function (){
+		let result = $(this).find('#qrm_roll_result').val();
+		if (result == ''){
+			//could swap this to an alert if people really think its needed...
+			console.log('No roll was performed on this token, but Apply was selected. Rerolling for ALL tokens.')
+			$('#qrm_roll_button').click()
+		}
+		
+		let token = window.TOKEN_OBJECTS[$(this).attr('data-target')]
+		hp_adjustment_failed_save = $('#hp_adjustment_failed_save').val()
+		half_damage_save_success = $('#half_damage_save').val()
+
+		hp_adjustment_failed_save = hp_adjustment_failed_save.replace(/[^\d.-]/g, '');
+		half_damage_save_success = half_damage_save_success.replace(/[^\d.-]/g, '');
+
+		if (result.includes('Fail')){
+			damage = hp_adjustment_failed_save || 0
+			let conditions = $('#qrm_apply_conditions')
+			let conditionName = conditions.val()
+			if(conditionName == 'conditions'){
+				//Do nothing
+			} 
+			else if(conditionName == "remove_all"){
+				//guess this is fine, we update the token immediately. Probably a better way to clear though
+				token.options.conditions = []
+				token.options.custom_conditions = []
+			}
+			else{
+				if(!token.hasCondition(conditionName)){
+					token.addCondition(conditionName, conditionName);
+				}
+			}	
+		}
+		else {
+			damage = half_damage_save_success || 0
+		}
+		if (healing == true){
+			damage = -damage
+		}
+		
+		if(token.options.monster > 0){
+			_hp = $(this).find('#qrm_hp');
+			_max_hp = $(this).find('#qrm_maxhp')
+			//Lets not allow healing over maxhp
+			//Unless we are at max_hp then assume they want the temp hp? IDK about this.
+			if (_hp.val() < _max_hp.val() && _hp.val() - damage > _max_hp.val()){
+				_hp.val(max_hp.val());
+			}
+			else{
+				_hp.val(token.options.hp - damage);
+			}
+			_hp.trigger('change');
+		}
+		else {
+			// doing it this way, because Players might also have resistances or abilites and they should manage their own HP. 
+			if (damage >= 0){
+				dmg_heal_text = token.options.name + " takes " + damage +" damage (adjust manually)";
+			}
+			else{
+				dmg_heal_text = token.options.name + " heals for " + damage +" (adjust manually)";
+			}
+				var msgdata = {
+				player: window.PLAYER_NAME,
+				img: window.PLAYER_IMG,
+				text: dmg_heal_text,
+			};
+			window.MB.inject_chat(msgdata);
+		}
+		//token.place_sync_persist();	
+		// bit of overlap with place_sync_persist nad update_and_sync, so probably break it up, just to only sync once.
+		token.place()
+		token.update_and_sync();
+		qrm_update_popout();
+	});
 }
 
 //end Quick Roll Menu//

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1730,16 +1730,11 @@ function open_quick_roll_menu(e){
 		$("#qrm_dialog").remove();
 	});
 	qrm_title_bar_popout.click(function() {
-		qrm.hide();
+		$("#qrm_dialog").hide();
 		let name = "Quick Roll Menu";
-		//We need to delete and reset the select menu here. The iconselectmenu doesn't clone right. so we need to delete and reinit. 
-		$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").iconselectmenu( "destroy" );
-		$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").iconselectmenu( "destroy" );
+		$('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').find(`option[value='${$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").val()}']`).attr('selected', 'selected');
+		$('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').find(`option[value='${$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").val()}']`).attr('selected', 'selected');	
 		popoutWindow(name, $("#qrm_dialog"), $("#qrm_dialog").width(),  $("#qrm_dialog").height()-25);//subtract titlebar height
-		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').prop('selectedIndex',0);
-		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').addClass( "ui-menu-icons" );
-		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').prop('selectedIndex',0);
-		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').addClass( "ui-menu-icons" );
 		qrm_update_popout();
 	})
 	qrm_title_bar.append(qrm_title_bar_popout);
@@ -1787,23 +1782,8 @@ function open_quick_roll_menu(e){
 	save_type_dropdown.append($(`<option value="3" data-name="int" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/intelligence.svg)'>Intelligence</option>`))
 	save_type_dropdown.append($(`<option value="5" data-name="cha" data-style='url(https://www.dndbeyond.com/content/1-0-1849-0/skins/waterdeep/images/icons/abilities/charisma.svg)'>Charisma</option>`))
 	//save_type_dropdown.tooltip({show: { duration: 1000 }})
-	save_type_dropdown.attr('style', 'width: 25% !important');
+	save_type_dropdown.attr('style', 'width: 22% !important');
 
-	$( function() {
-		$.widget( "custom.iconselectmenu", $.ui.selectmenu, {
-		_renderItem: function( ul, item ) {
-			var li = $( `<li class='icon-avatar' >` )
-			wrapper = $( "<div>", { text: item.label } );
-			$( "<li>", {
-			style: 'background-image: ' + item.element.attr( "data-style" ),
-			"class": "ui-icon " + item.element.attr( "data-class" )}).appendTo(wrapper);
-			return li.append( wrapper ).appendTo( ul );
-		}
-		});
-		$("#qrm_save_dropdown")
-		.iconselectmenu({ change: function( event, ui ) { save_type_change(this); }})
-    		.addClass( "ui-menu-icons" );
-	});
 
 	let damage_input  = $('<input class="menu_roll_input" id="hp_adjustment_failed_save" placeholder="Damage/Roll" title="Enter the integer value for damage or the roll to be made i.e. 8d6"></input>')
 	//damage_input.tooltip({show: { duration: 1000 }})
@@ -1952,32 +1932,18 @@ function open_quick_roll_menu(e){
 		}
 	});
 	
-	$( function() {
-		$.widget( "custom.iconselectmenu", $.ui.selectmenu, {
-		_renderItem: function( ul, item ) {
-			var li = $( `<li class='icon-avatar' >` )
-			wrapper = $( "<div>", { text: item.label } );
-			$( "<li>", {
-			style: item.element.attr( "data-style" ),
-			"class": "ui-icon " + item.element.attr( "data-class" )}).appendTo(wrapper);
-			return li.append( wrapper ).appendTo( ul );
-		}
-		});
-		$("#qrm_apply_conditions")
-		.iconselectmenu()
-    	.iconselectmenu( "menuWidget")
-    		.addClass( "ui-menu-icons" );
-	});
+
 	
 	let apply_adjustments = $('<button title="Apply Damage/Healing and Conditions on failed save" id="qrm_apply_adjustments" class="general_input"> Apply </button>')
 	apply_adjustments.click(function() {
-		qrm_apply_hp_adjustment(healing=$('#qrm_healing').val());
+		qrm_apply_hp_adjustment($('#qrm_healing').val());
 	});
 
 	let qrm_footer = $("<div id='quick_roll_footer' class='footer-input-wrapper tfoot'/>");
 	qrm_footer.css('bottom', '0');
 	qrm_footer.css('position','sticky');
 	qrm_footer.css('background', "#f9f9f9");
+	qrm_footer.css('height', 'fit-content');
 	
 	qrm_footer.append(damage_input)
 	qrm_footer.append(half_damage_input)
@@ -2087,41 +2053,51 @@ function add_to_quick_roll_menu(token){
 	roll_mod_adv = $('<button title="Advantage to roll" id="adv" name="roll_mod" value="OFF" class="roll_mods_button icon-advantage markers-icon" />')
 	//roll_mod_adv.tooltip({show: { duration: 1000 }})
 	roll_mod_adv.click(function(){
-		let roll_bonus_target=$(this).parent().parent().children('#roll_bonus');
+		let row_id = $(this).closest('tr').attr('data-target');
+		let target_button = $(`tr[data-target='${row_id}'] #adv`);
+		let roll_bonus_target = target_button.parent().parent().children('#roll_bonus');
 		roll_bonus_target.val(roll_bonus_target.val().replaceAll(/[ad]/gi, ''))
 	
-		let disadv_button = $(this).parent().children('#disadv');
+		let disadv_button = target_button.parent().children('#disadv');
 		$(disadv_button).val("OFF")
 		$(disadv_button).removeClass('active_roll_mod')
 		
-		if($(this).val() == "ON"){
-			$(this).val("OFF");
-			$(this).removeClass('active_roll_mod')
+		if(target_button.val() == "ON"){
+			target_button.val("OFF");
+			target_button.removeClass('active_roll_mod')
 		}
-	  	else if($(this).val() == "OFF"){
-			$(this).val("ON");
+	  	else if(target_button.val() == "OFF"){
+			target_button.val("ON");
 			roll_bonus_target.val(roll_bonus_target.val() + 'a')
-			$(this).addClass('active_roll_mod')
+			target_button.addClass('active_roll_mod')
+		}
+		if(childWindows['Quick Roll Menu']){
+			qrm_update_popout();
 		}
 	});
 	roll_mod_disadv = $('<button title="Disadvantage to roll" id="disadv" name="roll_mod" value="OFF" class="roll_mods_button icon-disadvantage markers-icon" />')
 	//roll_mod_disadv.tooltip({show: { duration: 1000 }})
 	roll_mod_disadv.click(function(){
-		let roll_bonus_target=$(this).parent().parent().children('#roll_bonus');
+		let row_id = $(this).closest('tr').attr('data-target');
+		let target_button = $(`tr[data-target='${row_id}'] #disadv`);
+		let roll_bonus_target=target_button.parent().parent().children('#roll_bonus');
 		roll_bonus_target.val(roll_bonus_target.val().replaceAll(/[ad]/gi, ''))
 
-		let adv_button = $(this).parent().children('#adv');
+		let adv_button = target_button.parent().children('#adv');
 		$(adv_button).val("OFF")
 		$(adv_button).removeClass('active_roll_mod')
 
-		if($(this).val() == "ON"){
-			$(this).val("OFF");
-			$(this).removeClass('active_roll_mod')
+		if(target_button.val() == "ON"){
+			target_button.val("OFF");
+			target_button.removeClass('active_roll_mod')
 		}
-	  	else if($(this).val() == "OFF"){
-			$(this).val("ON");
+	  	else if(target_button.val() == "OFF"){
+			target_button.val("ON");
 			roll_bonus_target.val(roll_bonus_target.val() + 'd')
-			$(this).addClass('active_roll_mod')
+			target_button.addClass('active_roll_mod')
+		}
+		if(childWindows['Quick Roll Menu']){
+			qrm_update_popout();
 		}
 	});
 	roll_mods.append(roll_mod_adv)
@@ -2393,10 +2369,9 @@ function convert_CR_to_proficiency(challenge_rating){
 function qrm_update_popout(){
 	
 	if(childWindows['Quick Roll Menu']){
-		//$(childWindows['Quick Roll Menu'].document).find("body").empty("");
 		updatePopoutWindow("Quick Roll Menu", $("#qrm_dialog"));
 		removeFromPopoutWindow("Quick Roll Menu", "#quick_roll_title_bar");
-		removeFromPopoutWindow("Quick Roll Menu", $("#qrm_dialog #quick_roll_footer #qrm_save_dropdown"));
+	
 		$(childWindows['Quick Roll Menu'].document).find("#qrm_dialog").css({
 			'display': 'block',
 			'top': '0',
@@ -2431,6 +2406,11 @@ function qrm_update_popout(){
 			$(`tr[data-target='${id}'] #roll_result`).trigger("change");
 			qrm_update_popout();
 		});	
+		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer input#damage_failed_save').change(function(e) {
+			$("#qrm_dialog #quick_roll_footer input#damage_failed_save").val($(this).val());
+			$("#qrm_dialog #quick_roll_footer input#damage_failed_save").trigger("change");
+			qrm_update_popout();
+		});
 		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save').change(function(e) {
 			$("#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save").val($(this).val());
 			$("#qrm_dialog #quick_roll_footer input#hp_adjustment_failed_save").trigger("change");
@@ -2445,24 +2425,66 @@ function qrm_update_popout(){
 			$("#qrm_dialog #quick_roll_footer input#qrm_save_dc").val($(this).val());
 			$('#qrm_dialog #quick_roll_footer input#qrm_save_dc').trigger("change");
 			qrm_update_popout();
-		});
-		//so we could redefine the iconselectmenu function here...but it doesn't work right and fixing it starts to get messy ...
-			
+		});			
 		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').change(function(e) {
+			$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").find(`option[selected='selected']`).removeAttr('selected');
+			$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").find(`option[value='${$(this).val()}']`).attr('selected', 'selected');
 			$("#qrm_dialog #quick_roll_footer select#qrm_save_dropdown").val($(this).val());
 			$('#qrm_dialog #quick_roll_footer select#qrm_save_dropdown').trigger("change");
 			qrm_update_popout();
 		});			
 		$(childWindows['Quick Roll Menu'].document).find('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').change(function(e) {
+			$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").find(`option[selected='selected']`).removeAttr('selected');
+			$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").find(`option[value='${$(this).val()}']`).attr('selected', 'selected');
 			$("#qrm_dialog #quick_roll_footer select#qrm_apply_conditions").val($(this).val());
 			$('#qrm_dialog #quick_roll_footer select#qrm_apply_conditions').trigger("change");
 			qrm_update_popout();
 		});
+	
+		$(childWindows['Quick Roll Menu'].document).find("#qrm_damage").click(function(){
+			let heal_hp = $("#qrm_healing");
+			let damage_hp = $("#qrm_damage");
+			//toggle off the other button
+			$(heal_hp).val("OFF")
+			$(heal_hp).removeClass('active_roll_mod')
+			
+			if($(damage_hp).val() == "ON"){
+				$(damage_hp).val("OFF");
+				$(damage_hp).removeClass('active_roll_mod')
+			}
+		  	else if($(damage_hp ).val() == "OFF"){
+				$(damage_hp).val("ON");
+				$(damage_hp).addClass('active_roll_mod')
+			}
+			qrm_update_popout();
+		});
+		$(childWindows['Quick Roll Menu'].document).find("#qrm_healing").click(function(){
+			let heal_hp = $("#qrm_healing");
+			let damage_hp = $("#qrm_damage");
+
+			//toggle off the other button
+			$(damage_hp).val("OFF")
+			$(damage_hp).removeClass('active_roll_mod')
+
+			if($(heal_hp).val() == "ON"){
+				$(heal_hp).val("OFF");
+				$(heal_hp).removeClass('active_roll_mod')
+			}
+		  	else if($(heal_hp).val() == "OFF"){
+				$(heal_hp).val("ON");
+				$(heal_hp).addClass('active_roll_mod')
+			}
+			qrm_update_popout();
+		});
+
 		
 	}
 }
 
 function qrm_apply_hp_adjustment(healing=false){
+	if(healing == 'ON'){
+		healing = true;
+	}
 	$("#quick_roll_area").children('tr').each(function (){
 		let result = $(this).find('#qrm_roll_result').val();
 		if (result == ''){
@@ -2472,12 +2494,13 @@ function qrm_apply_hp_adjustment(healing=false){
 		}
 		
 		let token = window.TOKEN_OBJECTS[$(this).attr('data-target')]
-		hp_adjustment_failed_save = $('#hp_adjustment_failed_save').val()
-		half_damage_save_success = $('#half_damage_save').val()
+		let hp_adjustment_failed_save = $('#hp_adjustment_failed_save').val()
+		let half_damage_save_success = $('#half_damage_save').val()
 
 		hp_adjustment_failed_save = hp_adjustment_failed_save.replace(/[^\d.-]/g, '');
 		half_damage_save_success = half_damage_save_success.replace(/[^\d.-]/g, '');
 
+		let damage;
 		if (result.includes('Fail')){
 			damage = hp_adjustment_failed_save || 0
 			let conditions = $('#qrm_apply_conditions')
@@ -2504,12 +2527,15 @@ function qrm_apply_hp_adjustment(healing=false){
 		}
 		
 		if(token.options.monster > 0){
-			_hp = $(this).find('#qrm_hp');
-			_max_hp = $(this).find('#qrm_maxhp')
+			let _hp = $(this).find('#qrm_hp');
+			let _max_hp = $(this).find('#qrm_maxhp');
+
+			let _hp_val = parseInt($(this).find('#qrm_hp').val());//make string an int before comparing otherwise '11' is less than '6'
+			let _max_hp_val = parseInt($(this).find('#qrm_maxhp').val())
 			//Lets not allow healing over maxhp
 			//Unless we are at max_hp then assume they want the temp hp? IDK about this.
-			if (_hp.val() < _max_hp.val() && _hp.val() - damage > _max_hp.val()){
-				_hp.val(max_hp.val());
+			if (_hp_val < _max_hp_val && _hp_val - damage > _max_hp_val){
+				_hp.val(_max_hp_val);
 			}
 			else{
 				_hp.val(token.options.hp - damage);
@@ -2518,6 +2544,7 @@ function qrm_apply_hp_adjustment(healing=false){
 		}
 		else {
 			// doing it this way, because Players might also have resistances or abilites and they should manage their own HP. 
+			let dmg_heal_text;
 			if (damage >= 0){
 				dmg_heal_text = token.options.name + " takes " + damage +" damage (adjust manually)";
 			}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6598,7 +6598,7 @@ button.journal-view-button.journal-button {
     transition: color 0.3s ease-in-out, background 0.3s ease-in-out, background-color 0.3s ease-in-out, background-image 0.1s ease-in-out;
     border: 1px solid lightgray;
     font-size: 12px;
-    overflow: auto;
+    overflow: hidden;
 }
 .qrm_name_line{
     text-align: left;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6594,10 +6594,11 @@ button.journal-view-button.journal-button {
     margin: 0 2px;
     border-radius: 7px;
     box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%), 0 1px 2px rgb(0 0 0 / 5%);
-    padding: 2px 8px;
+    padding: 2px 4px;
     transition: color 0.3s ease-in-out, background 0.3s ease-in-out, background-color 0.3s ease-in-out, background-image 0.1s ease-in-out;
     border: 1px solid lightgray;
     font-size: 12px;
+    overflow: auto;
 }
 .qrm_name_line{
     text-align: left;
@@ -6615,7 +6616,6 @@ button.journal-view-button.journal-button {
     border-radius: 3px;
     border-color: #ddd;
     height:22px;
-    text-align:center;
     font-size: 14px !important;
     box-shadow: 1px 1px 1px 0px #00000047;
 }
@@ -6632,6 +6632,7 @@ button.journal-view-button.journal-button {
     border: 1px solid lightgray;
     font-size: 12px;
     margin: 1px;
+    top: -1px;
 }
 .menu_hp_input{
     border-width: 0;
@@ -6663,18 +6664,134 @@ button.journal-view-button.journal-button {
 .roll_mods_button:focus {
     outline: none;
     box-shadow: none;
-  }
-#adv.active_roll_mod{
+}
+#qrm_healing.active_roll_mod, #adv.active_roll_mod{
     background-image: none !important;
     background: green;
     border-radius: 3px !important;
     border-color: #ddd !important;
 }
-#disadv.active_roll_mod{
+#qrm_damage.active_roll_mod, #disadv.active_roll_mod{
     background-image: none !important;
     background: red;
     border-radius: 3px;
     border-color: #ddd;
+}
+#qrm_heal.active_roll_mod{
+    background-image: none !important;
+    background: green;
+    border-radius: 3px !important;
+    border-color: #ddd !important;
+}
+#qrm_damage.active_roll_mod{
+    background-image: none !important;
+    background: red;
+    border-radius: 3px;
+    border-color: #ddd;
+}
+.adjustments_wrapper{
+    top: 5px;
+    position: relative;
+    display: inline-block;
+}
+.damage_heal_button{
+    display: block;
+    height: 50% !important;
+    font-size: 8px !important;
+    text-align: center;
+    overflow: unset!important;
+    padding: 0px!important;
+    width: 50px;
+    margin: 1px !important;
+}
+.ui-selectmenu-menu .ui-menu-item-wrapper .ui-menu-item {
+    height: 24px;
+    width: 24px;
+    top: 0.1em;
+    overflow: auto;
+    position: relative;
+}
+.ui-selectmenu-menu .ui-menu {
+    max-height: calc(50vh - 20px);
+    width: 140px;
+    overflow: auto !important;
+}
+.ui-front {
+    z-index: 50010 !important;
+}
+.ui-selectmenu-text{
+    top: 1px;
+    position: relative;
+}
+.ui-menu .ui-menu-item-wrapper{
+    display: inline-block;
+    padding-right: 100px !important;
+    max-width: 175px;
+    white-space: nowrap;
+}
+.icon-avatar{
+    width: 22px;
+    height: 22px;
+}
+.ui-selectmenu-button.ui-button{
+    width: 22% !important;
+    padding: 2px 2px !important;
+    border-width: 2px;
+    border-radius: 2px;
+    border-color: #ddd;
+    background-image: -webkit-linear-gradient(top, #fff, #e6e6e6);
+    color: #3d3d3d;
+    height: 22px;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%), 0 1px 2px rgb(0 0 0 / 5%);
+    transition: color 0.3s ease-in-out, background 0.3s ease-in-out, background-color 0.3s ease-in-out, background-image 0.1s ease-in-out;
+    border: 1px solid lightgray;
+    font-size: 12px;
+    margin: 1px;
+    top: -1px;
+}
+.ui-menu .ui-icon{
+    background-image: none;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+.dropdown-advantage {
+    background-image: url(assets/conditons/advantage.png) !important;
+}
+.dropdown-baned {
+    background-image: url(assets/conditons/baned.png) !important;
+}
+.dropdown-bardic {
+    background-image: url(assets/conditons/bardic_inspiration.png) !important;
+}
+.dropdown-blessed{
+    background-image: url(assets/conditons/blessed.png) !important;
+}
+.dropdown-bloodied {
+    background-image: url(assets/conditons/bloodied.png) !important;
+}
+.dropdown-concentration-reminder {
+    background-image: url(assets/conditons/concentration\(reminder\).png) !important;
+}
+.dropdown-disadvantage {
+    background-image: url(assets/conditons/disadvantage.png) !important;
+}
+.dropdown-flamed {
+    background-image: url(assets/conditons/flamed.png) !important;
+}
+.dropdown-flying {
+    background-image: url(assets/conditons/flying.png) !important;
+}
+.dropdown-hasted {
+    background-image: url(assets/conditons/hasted.png) !important;
+}
+.dropdown-bardic-inspiration {
+    background-image: url(assets/conditons/bardic_inspiration.png) !important;
+}
+.dropdown-rage {
+    background-image: url(assets/conditons/rage.png) !important;
+}
+.dropdown-remove {
+    background-image: url(assets/icons/delete.svg) !important;
 }
 /* end quick roll menu */
 


### PR DESCRIPTION
I like your updates a lot.

This fixes quite a few of the popout issues. I'm just using the base select menus instead of the full icon menus here to get them to work. You still might be able to get them to display the icons. 

There's two ways to set up events for buttons in the popouts I show both here.

The damage/heal buttons I added event listeners too the popup instead of changing $(this) in the original events. 

The adv/disadv buttons I added some logic to the original events that grab the row id then apply it to the appropriate buttons in the main window. Then if the popout window exists update it

`$(this)` when cloned will target the popup window instead of the main window. But when we run the popup window update it overrides it with the original window data - erasing the update. We also generally grab data from the original window for healing etc. So how you do it is preference/ease at the time - you can either adjust the original event listeners or add new ones to the window if $(this) is used.

You may want to capitalize the menu items. The hp inputs also aren't setup in the popout.

 I can go through and do those later if you don't get to them - I just ran out of time while doing this and thought I'd put up a PR on yours before I had to head out.